### PR TITLE
Parity version should always be stable

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
 NETWORK_NAME=parity-poa-playground
-PARITY_VERSION=v2.2.11
+PARITY_VERSION=stable


### PR DESCRIPTION
Due to changing version specific versions become obsolete after some time. Stable version should always be available and stable.

Although the specific version is always a preferred way of interacting with Docker containers this fix would resolve a problem of unable been to pull specific image version.